### PR TITLE
Fix fatal error when creating a new user

### DIFF
--- a/src/admin/UserAdmin.php
+++ b/src/admin/UserAdmin.php
@@ -138,7 +138,7 @@ class UserAdmin extends Admin
 			$input['password'] = Hash::make($input['password']);
 		}
 
-		User::create($input);
+		return User::create($input);
 	}
 
 	/**


### PR DESCRIPTION
The Model::create() method is expected to return an instance of Model

This was also reported/fixed by @TimBroddin in #7 but I'm submitting it again since his hasn't been merged yet.